### PR TITLE
Support missing configs

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = function(source) {
   this.cacheable(true);
   var callback = this.async();
 
-  var config = loaderUtils.getOptions(this);
+  var config = loaderUtils.getOptions(this) || {};
 
   // This piece of code exists in order to support webpack 1.x.x top level configurations.
   // In webpack 2 this options does not exists anymore.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svgo-loader",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "svgo loader for webpack",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`loaderUtils.getOptions(this)` will return `null` if no parseable structure is found. We don't currently `null` check this when reading `useConfig`.

https://github.com/webpack/loader-utils#user-content-getoptions

I have added a default empty object as a fallback for this scenario.